### PR TITLE
Adds {book_name_abbreviated} and {book_name_full} substitution tokens.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -20,6 +20,7 @@ import { mb } from 'api'
 const BUILD_END_TOAST = "Bible build finished!";
 const SELECTED_TRANSLATION_OPTION = "<Selected reading translation, {0}>"
 const SELECTED_TRANSLATION_OPTION_KEY = "default"
+enum BookNameStyle { Display, Abbreviated, Full }
 
 // Remember to rename these classes and interfaces!
 
@@ -695,7 +696,10 @@ class BuildContext {
 		return name.replace(delimeter, "").slice(0,3);
 	}
 
-	format_book_name(book:BookData|undefined=undefined): string {
+	format_book_name(
+		book:BookData|undefined=undefined,
+		style: BookNameStyle|undefined=BookNameStyle.Display,
+	): string {
 		if (book === undefined) {
 			book = this.book
 		}
@@ -706,10 +710,10 @@ class BuildContext {
 			delim
 		)
 
-		if (this.plugin.settings.book_name_abbreviated) {
+		if ( (style === BookNameStyle.Abbreviated) ||
+		     (style === BookNameStyle.Display && this.plugin.settings.book_name_abbreviated) ) {
 			book_name = this.abbreviate_book_name(book_name, delim)
-		}
-
+			 }
 		return this.plugin.settings.book_name_format
 			.replace(/{translation}/g, String(this.translation))
 			.replace(/{book}/g, book_name)
@@ -723,6 +727,7 @@ class BuildContext {
 	format_book_name_without_order(
 		book:BookData|undefined=undefined,
 		casing:string|undefined=undefined,
+		style: BookNameStyle|undefined=BookNameStyle.Display,
 	): string {
 		if (book === undefined) {
 			book = this.book
@@ -737,9 +742,10 @@ class BuildContext {
 			delim
 		)
 
-		if (this.plugin.settings.book_name_abbreviated) {
+		if ( (style === BookNameStyle.Abbreviated) ||
+		     (style === BookNameStyle.Display && this.plugin.settings.book_name_abbreviated) ) {
 			book_name = this.abbreviate_book_name(book_name, delim)
-		}
+			 }
 
 		return book_name
 	}
@@ -748,6 +754,8 @@ class BuildContext {
 		return this.plugin.settings.chapter_body_format
 			.replace(/{translation}/g, String(this.translation))
 			.replace(/{book}/g, this.format_book_name_without_order(this.book))
+			.replace(/{book_name_full}/g, this.format_book_name_without_order(this.book, undefined, BookNameStyle.Full))
+			.replace(/{book_name_abbreviated}/g, this.format_book_name_without_order(this.book, undefined, BookNameStyle.Abbreviated))
 			.replace(
 				/{order}/g,
 				String(this.book_order(this.book))
@@ -885,6 +893,8 @@ class BuildContext {
 		return this.plugin.settings.verse_body_format
 			.replace(/{translation}/g, String(this.translation))
 			.replace(/{book}/g, book_name)
+			.replace(/{book_name_full}/g, this.format_book_name_without_order(this.book, undefined, BookNameStyle.Full))
+			.replace(/{book_name_abbreviated}/g, this.format_book_name_without_order(this.book, undefined, BookNameStyle.Abbreviated))
 			.replace(/{book_id}/g, String(this.book.id))
 			.replace(
 				/{order}/g,
@@ -915,6 +925,8 @@ class BuildContext {
 		return this.plugin.settings.chapter_index_format
 			.replace(/{translation}/g, String(this.translation))
 			.replace(/{book}/g, book_name)
+			.replace(/{book_name_full}/g, this.format_book_name_without_order(book, undefined, BookNameStyle.Full))
+			.replace(/{book_name_abbreviated}/g, this.format_book_name_without_order(book, undefined, BookNameStyle.Abbreviated))
 			.replace(/{order}/g, String(this.book_order(book)).padStart(2 * Number(this.plugin.settings.padded_order), "0"))
 			.replace(/{index}/g, this.format_index_name())
 			.replace(/{chapters}/g, chapter_links)
@@ -939,6 +951,8 @@ class BuildContext {
 		return this.plugin.settings.chapter_index_link_format
 			.replace(/{translation}/g, String(this.translation))
 			.replace(/{book}/g, book_name)
+			.replace(/{book_name_full}/g, this.format_book_name_without_order(book, undefined, BookNameStyle.Full))
+			.replace(/{book_name_abbreviated}/g, this.format_book_name_without_order(book, undefined, BookNameStyle.Abbreviated))
 			.replace(/{order}/g, String(this.book_order(book)).padStart(2 * Number(this.plugin.settings.padded_order), "0"))
 			.replace(/{chapter}/g, String(chapter))
 			.replace(/{chapter_name}/g, this.format_chapter_name("custom", chapter))
@@ -952,6 +966,8 @@ class BuildContext {
 		return this.plugin.settings.chapter_index_name_format
 			.replace(/{order}/g, String(this.book_order(book)).padStart(2 * Number(this.plugin.settings.padded_order), "0"))
 			.replace(/{book}/g, book_name)
+			.replace(/{book_name_full}/g, this.format_book_name_without_order(book, undefined, BookNameStyle.Full))
+			.replace(/{book_name_abbreviated}/g, this.format_book_name_without_order(book, undefined, BookNameStyle.Abbreviated))
 			.replace(/{translation}/g, String(this.translation))
 	}
 


### PR DESCRIPTION
Addresses issue #57 

This adds two new tokens - {book_name_abbreviated} and {book_name_full} to compliment the existing {book} token.

This patch makes every effort to not make changes that would affect or break current implementations.  For that reason, certain decisions were made.

- The addition of an enum 'BookNameStyle':  The naming here may be clumsy, but I was careful to avoid using words like 'Format' which are already widely used in the project for different purposes to help distinguish the change.
- Where 'BookNameStyle' is used, it sanely defaults to 'Display' which is functionally equivalent to the user's preference as set in the 'Build Bible' modal.  This way no changes needed to be made elsewhere in the code.  Method calls require no alterations.
- {book} is left unchanged.  {book} continues to return the book name in the user's defined preference.
- {book_name_abbreviated} always returns the abbreviated book name, regardless of user settings
- {book_name_full} always returns the full book name, regardless of user settings
